### PR TITLE
Add changeWorkspace method

### DIFF
--- a/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
+++ b/intercom_flutter/android/src/main/kotlin/io/maido/intercom/IntercomFlutterPlugin.kt
@@ -298,6 +298,16 @@ class IntercomFlutterPlugin : FlutterPlugin, MethodCallHandler, EventChannel.Str
           })
         }
       }
+      "changeWorkspace" -> {
+        val appId = call.argument<String>("appId")
+        val androidApiKey = call.argument<String>("androidApiKey")
+        if (appId != null && androidApiKey != null) {
+          Intercom.client().changeWorkspace(androidApiKey, appId)
+          result.success("Workspace changed")
+        } else {
+          result.error("INVALID_ARGUMENTS", "appId and androidApiKey are required", null)
+        }
+      }
       else -> result.notImplemented()
     }
   }

--- a/intercom_flutter/ios/Classes/IntercomFlutterPlugin.m
+++ b/intercom_flutter/ios/Classes/IntercomFlutterPlugin.m
@@ -285,6 +285,20 @@ id unread;
                                            details: [self getIntercomError:errorCode:errorMsg]]);
             }];
         }
+    } else if([@"changeWorkspace" isEqualToString:call.method]) {
+        NSString *iosApiKey = call.arguments[@"iosApiKey"];
+        NSString *appId = call.arguments[@"appId"];
+        if (iosApiKey != nil && iosApiKey != (id)[NSNull null] &&
+            appId != nil && appId != (id)[NSNull null]) {
+            // iOS doesn't have native changeWorkspace, so logout and re-initialize
+            [Intercom logout];
+            [Intercom setApiKey:iosApiKey forAppId:appId];
+            result(@"Workspace changed");
+        } else {
+            result([FlutterError errorWithCode:@"INVALID_ARGUMENTS"
+                                       message:@"appId and iosApiKey are required"
+                                       details:nil]);
+        }
     }
     else {
         result(FlutterMethodNotImplemented);

--- a/intercom_flutter/lib/intercom_flutter.dart
+++ b/intercom_flutter/lib/intercom_flutter.dart
@@ -304,4 +304,19 @@ class Intercom {
   Future<void> setAuthTokens(Map<String, String> tokens) {
     return IntercomFlutterPlatform.instance.setAuthTokens(tokens);
   }
+
+  /// Changes the Intercom workspace.
+  ///
+  /// On Android: Uses native changeWorkspace API (SDK 16.1.0+)
+  /// On iOS: Logs out and re-initializes with new credentials
+  ///
+  /// This will logout the current user and clear all SDK data.
+  /// You must call login again after changing workspace.
+  ///
+  /// [appId] is required for both platforms.
+  /// [androidApiKey] is required for Android.
+  /// [iosApiKey] is required for iOS.
+  Future<void> changeWorkspace(String appId, {String? androidApiKey, String? iosApiKey}) {
+    return IntercomFlutterPlatform.instance.changeWorkspace(appId, androidApiKey: androidApiKey, iosApiKey: iosApiKey);
+  }
 }

--- a/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
+++ b/intercom_flutter_platform_interface/lib/intercom_flutter_platform_interface.dart
@@ -295,4 +295,19 @@ abstract class IntercomFlutterPlatform extends PlatformInterface {
   Future<void> setAuthTokens(Map<String, String> tokens) {
     throw UnimplementedError('setAuthTokens() has not been implemented.');
   }
+
+  /// Changes the Intercom workspace.
+  ///
+  /// On Android: Uses native changeWorkspace API (SDK 16.1.0+)
+  /// On iOS: Logs out and re-initializes with new credentials
+  ///
+  /// This will logout the current user and clear all SDK data.
+  /// You must call login again after changing workspace.
+  ///
+  /// [appId] is required for both platforms.
+  /// [androidApiKey] is required for Android.
+  /// [iosApiKey] is required for iOS.
+  Future<void> changeWorkspace(String appId, {String? androidApiKey, String? iosApiKey}) {
+    throw UnimplementedError('changeWorkspace() has not been implemented.');
+  }
 }

--- a/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
+++ b/intercom_flutter_platform_interface/lib/method_channel_intercom_flutter.dart
@@ -265,6 +265,11 @@ class MethodChannelIntercomFlutter extends IntercomFlutterPlatform {
     await _channel.invokeMethod('setAuthTokens', {'tokens': tokens});
   }
 
+  @override
+  Future<void> changeWorkspace(String appId, {String? androidApiKey, String? iosApiKey}) async {
+    await _channel.invokeMethod('changeWorkspace', {'appId': appId, 'androidApiKey': androidApiKey, 'iosApiKey': iosApiKey});
+  }
+
   /// Convert the [PlatformException] details to [IntercomError].
   /// From the Platform side if the intercom operation failed then error details
   /// will be sent as details in [PlatformException].

--- a/intercom_flutter_web/lib/intercom_flutter_web.dart
+++ b/intercom_flutter_web/lib/intercom_flutter_web.dart
@@ -352,6 +352,18 @@ class IntercomFlutterWeb extends IntercomFlutterPlatform {
     print("Auth tokens added");
   }
 
+  @override
+  Future<void> changeWorkspace(String appId, {String? androidApiKey, String? iosApiKey}) async {
+    // For web, we shutdown the current workspace and boot with the new appId
+    // Clear user data first
+    removeIntercomSettings(['user_hash', 'intercom_user_jwt', 'user_id', 'email', 'auth_tokens']);
+    // Shutdown current workspace
+    globalContext.callMethod('Intercom'.toJS, 'shutdown'.toJS);
+    // Boot with new workspace
+    globalContext.callMethod('Intercom'.toJS, 'boot'.toJS, updateIntercomSettings('app_id', appId).jsify());
+    print("Workspace changed");
+  }
+
   /// get the [window.intercomSettings]
   Map<dynamic, dynamic> getIntercomSettings() {
     if (globalContext.hasProperty('intercomSettings'.toJS).toDart) {


### PR DESCRIPTION
## Summary
- Adds `changeWorkspace()` method to allow switching between Intercom workspaces
- Android: Uses native `changeWorkspace` API (SDK 16.1.0+)
- iOS: Implements via logout and re-initialization pattern
- Web: Implements via shutdown and boot with new app ID
- Includes platform-specific API key parameters (`androidApiKey`, `iosApiKey`)

## Implementation Details
- Platform interface updated with new method signature
- Method channel implementation added for iOS/Android
- Web implementation using Intercom JS SDK
- Proper error handling for missing required parameters
- Code formatting improvements across multiple files

## Test Plan
- [ ] Test workspace change on Android with valid credentials
- [ ] Test workspace change on iOS with valid credentials
- [ ] Test workspace change on Web with valid app ID
- [ ] Verify user is logged out after workspace change
- [ ] Test that login works correctly after workspace change
- [ ] Test error handling with missing parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)