### PR TITLE
fix(android): remove PushInterceptReceiver to prevent duplicate push notifications 

### DIFF
--- a/intercom_flutter/CHANGELOG.md
+++ b/intercom_flutter/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 9.6.3
+
+* Fix duplicate Android push notifications by removing `PushInterceptReceiver` from the merged manifest via `tools:node="remove"`. The legacy GCM/C2DM receiver was firing alongside `IntercomFcmMessengerService`, causing every Intercom push to trigger twice.
+
 ## 9.6.2
 
 * Removed deprecated `handlePushMessage` API (removed from native Intercom SDK)

--- a/intercom_flutter/android/src/main/AndroidManifest.xml
+++ b/intercom_flutter/android/src/main/AndroidManifest.xml
@@ -1,11 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="io.maido.intercom">
 
   <application>
     <receiver
       android:name="io.maido.intercom.PushInterceptReceiver"
       android:exported="true"
-      android:permission="com.google.android.c2dm.permission.SEND">
+      android:permission="com.google.android.c2dm.permission.SEND"
+      tools:node="remove">
       <intent-filter>
         <action android:name="com.google.android.c2dm.intent.RECEIVE" />
       </intent-filter>

--- a/intercom_flutter/pubspec.yaml
+++ b/intercom_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 9.6.2
+version: 9.6.3
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:


### PR DESCRIPTION
## Problem

On Android devices that still trigger the legacy `com.google.android.c2dm.intent.RECEIVE` broadcast (older Android versions and certain OEM builds), Intercom push notifications are displayed **twice**.

## Root Cause

The merged Android manifest ends up with two simultaneous Intercom push handlers:

| Handler | Registered by | Trigger |
|---|---|---|
| `io.maido.intercom.PushInterceptReceiver` | `intercom_flutter` plugin manifest | `com.google.android.c2dm.intent.RECEIVE` (legacy C2DM broadcast) |
| `io.intercom.android.sdk.fcm.IntercomFcmMessengerService` | `intercom-sdk-fcm` AAR (transitive dep of `intercom-sdk`) | `com.google.firebase.MESSAGING_EVENT` (modern Firebase path) |

On affected devices, both handlers receive the same push payload and independently call `handlePush()`, resulting in two notifications being displayed.

`IntercomFcmMessengerService` is included automatically as a transitive dependency whenever `intercom-sdk` is used — meaning both handlers are always present when `initSdk()` is called in the Application class per the recommended setup.

## Fix

Remove `PushInterceptReceiver` from the plugin's `AndroidManifest.xml`. `IntercomFcmMessengerService` (registered by the native SDK's own AAR) is the intended modern handler and covers all cases including background and killed-state delivery when `initSdk()` is called in the Application class.

**Removed from `android/src/main/AndroidManifest.xml`:**

```xml
<receiver
    android:name="io.maido.intercom.PushInterceptReceiver"
    android:exported="true"
    android:permission="com.google.android.c2dm.permission.SEND">
    <intent-filter>
        <action android:name="com.google.android.c2dm.intent.RECEIVE" />
    </intent-filter>
</receiver>
```

`PushInterceptReceiver.kt` can also be removed entirely as it becomes unreachable.

## Testing

Tested on an affected device (OEM build still triggering the C2DM broadcast):
- Before fix: every Intercom push notification displayed twice
- After fix: single notification displayed correctly
- Background and killed-state push delivery unaffected
